### PR TITLE
fix: 调整返回按钮图标尺寸与对齐

### DIFF
--- a/src/components/toc-return-tools/TocReturnTools.css
+++ b/src/components/toc-return-tools/TocReturnTools.css
@@ -13,6 +13,10 @@
 		flex-direction: row-reverse;
 		justify-content: unset !important;
 	}
+
+	svg {
+		margin: -2px;
+	}
 }
 
 .NToc__return-button-master {

--- a/src/components/toc-return-tools/TocReturnTools.tsx
+++ b/src/components/toc-return-tools/TocReturnTools.tsx
@@ -96,7 +96,7 @@ export const TocReturnTools: FC<TocReturnToolsProps> = ({
 				className="NToc__return-button-master"
 				onClick={handleMasterClick}
 			>
-				<Component size={16} />
+				<Component size={24} />
 			</button>
 
 			{/* 展开的工具按钮 */}


### PR DESCRIPTION
将返回按钮图标尺寸从16 调整为 24，并在样式中为 svg
增加 -2px 的 margin 以修正视觉中心位置。这样做是为了解决
图标在按钮内显得过小且未居中的问题，提升触控可点面积和
视觉一致性。